### PR TITLE
Heroku Demo

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: python manage.py migrate
+web: gunicorn config.wsgi:application

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: python manage.py migrate
+release: chmod +x compose/demo/release.sh && ./compose/demo/release.sh
 web: gunicorn config.wsgi:application

--- a/compose/demo/release.sh
+++ b/compose/demo/release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# this script is run by heroku before running the new demo
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# TODO: flush db, create superuser, load fixtures, add demo data
+python manage.py collectstatic --no-input
+python manage.py migrate
+

--- a/config/settings/demo.py
+++ b/config/settings/demo.py
@@ -1,0 +1,13 @@
+
+from .production import *
+
+# Dont bother with REDIS for demo
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "",
+    }
+}
+
+# Use django default static storage
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"


### PR DESCRIPTION
Add config for deploying to Heroku. Heroku has a free tier that gives 550 free hours per month and sleeps when inactive for 30 min, so it can work as our demo site. It also supports GitHub integration, so it can automatically rebuild and redeploy every time there is a change to master, so no one should ever have to touch it again....

https://oslerdemo.herokuapp.com/
